### PR TITLE
Declare leaflet-draw as module

### DIFF
--- a/leaflet-draw/leaflet-draw.d.ts
+++ b/leaflet-draw/leaflet-draw.d.ts
@@ -5,6 +5,8 @@
 
 /// <reference path="../leaflet/leaflet-0.7.d.ts" />
 
+declare module 'leaflet-draw' {}
+
 declare namespace L {
 	export interface MapOptions {
 		drawControl?: boolean;


### PR DESCRIPTION
Declare leaflet-draw as module to support module bundler environments such as Webpack or Browserify.